### PR TITLE
Make photo action buttons always visible on mobile

### DIFF
--- a/frontend/components/gallery/folder-grid.tsx
+++ b/frontend/components/gallery/folder-grid.tsx
@@ -132,8 +132,8 @@ export function FolderGrid({
           />
 
           {/* Action overlay */}
-          <div className="absolute inset-0 bg-black/0 group-hover:bg-black/5 transition-colors duration-200 flex items-end justify-center pb-2">
-            <div className="flex gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+          <div className="absolute inset-0 bg-black/0 lg:group-hover:bg-black/5 transition-colors duration-200 flex items-end justify-center pb-2">
+            <div className="flex gap-1.5 opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity duration-200">
               <Button
                 size="sm"
                 variant="secondary"

--- a/frontend/components/photo/photo-grid.tsx
+++ b/frontend/components/photo/photo-grid.tsx
@@ -178,8 +178,8 @@ export function PhotoGrid({
             />
 
             {/* Action overlay - positioned at bottom to avoid overlap with like/favorite */}
-            <div className="absolute inset-0 bg-black/0 group-hover:bg-black/5 transition-all flex items-end justify-center pb-2">
-              <div className="flex gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+            <div className="absolute inset-0 bg-black/0 lg:group-hover:bg-black/5 transition-all flex items-end justify-center pb-2">
+              <div className="flex gap-1.5 opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity">
                 {onView && (
                   <Button
                     size="sm"


### PR DESCRIPTION
This change ensures that the photo action buttons (download, view, delete, etc.) are always visible on mobile devices (specifically screens smaller than `lg` breakpoint, 1024px), addressing the issue where users on iPhone Safari could not see these buttons because they relied on hover state. On desktop, the buttons remain hidden until the user hovers over the photo.

Changes:
- Modified `frontend/components/photo/photo-grid.tsx`
- Modified `frontend/components/gallery/folder-grid.tsx`

---
*PR created automatically by Jules for task [4698774804065294374](https://jules.google.com/task/4698774804065294374) started by @Sinnan1*